### PR TITLE
Removed $themeconf.name to allow for child themes

### DIFF
--- a/template/header.tpl
+++ b/template/header.tpl
@@ -28,15 +28,15 @@
 {if isset($last.U_IMG)    }    <link rel="last" title="{'Last'|@translate}" href="{$last.U_IMG}" >{/if}
 {if isset($U_UP)          }    <link rel="up" title="{'Thumbnails'|@translate}" href="{$U_UP}" >{/if}
 
-{combine_css path="themes/`$themeconf.name`/bootstrap/dist/css/bootstrap.min.css" order=-20}
-{combine_css path="themes/`$themeconf.name`/bootstrap/dist/css/bootstrap-theme.min.css" order=-20}
+{combine_css path="themes/bootstrapdefault/bootstrap/dist/css/bootstrap.min.css" order=-20}
+{combine_css path="themes/bootstrapdefault/bootstrap/dist/css/bootstrap-theme.min.css" order=-20}
 {foreach from=$themes item=theme}
 {if $theme.load_css}
     {combine_css path="themes/`$theme.id`/theme.css" order=-10}
 {/if}
 {if !empty($theme.local_head)}{include file=$theme.local_head load_css=$theme.load_css}{/if}
 {/foreach}
-{combine_css path="themes/`$themeconf.name`/fixplugins.css" order=1000000}
+{combine_css path="themes/bootstrapdefault/fixplugins.css" order=1000000}
     {get_combined_css}
 
 {if isset($U_PREFETCH)}    <link rel="prefetch" href="{$U_PREFETCH}">{/if}
@@ -47,8 +47,8 @@
 {combine_script id='jquery'}
 {combine_script id='jquery-ajaxmanager' require='jquery' path='themes/default/js/plugins/jquery.ajaxmanager.js'}
 {combine_script id='thumbnails-loader' require='jquery-ajaxmanager' path='themes/default/js/thumbnails.loader.js'}
-{combine_script id='bootstrap' require='jquery' path="themes/`$themeconf.name`/bootstrap/dist/js/bootstrap.min.js"}
-{combine_script id=$themeconf.name require='bootstrap' path="themes/`$themeconf.name`/js/theme.js"}
+{combine_script id='bootstrap' require='jquery' path="themes/bootstrapdefault/bootstrap/dist/js/bootstrap.min.js"}
+{combine_script id=$themeconf.name require='bootstrap' path="themes/bootstrapdefault/js/theme.js"}
     {get_combined_scripts load='header'}
 
     <!--[if lt IE 7]>

--- a/template/index.tpl
+++ b/template/index.tpl
@@ -1,7 +1,7 @@
 <!-- Start of index.tpl -->
 {combine_script id='core.switchbox' require='jquery' path='themes/default/js/switchbox.js'}
-{combine_script id='cookie' require='jquery' path="themes/`$themeconf.name`/js/jquery.cookie.js"}
-{combine_script id='equalheights' require='jquery' path="themes/`$themeconf.name`/js/jquery.equalheights.js"}
+{combine_script id='cookie' require='jquery' path="themes/bootstrapdefault/js/jquery.cookie.js"}
+{combine_script id='equalheights' require='jquery' path="themes/bootstrapdefault/js/jquery.equalheights.js"}
 {if !empty($PLUGIN_INDEX_CONTENT_BEFORE)}{$PLUGIN_INDEX_CONTENT_BEFORE}{/if}
 
 <nav class="navbar navbar-default" role="navigation">

--- a/template/picture.tpl
+++ b/template/picture.tpl
@@ -244,7 +244,7 @@
 {/if}
 {/foreach}
 {strip}{combine_script id='core.scripts' load='async' path='themes/default/js/scripts.js'}
-{combine_script id='rating' load='async' require='core.scripts' require='jquery' path="themes/`$themeconf.name`/js/rating.js"}
+{combine_script id='rating' load='async' require='core.scripts' require='jquery' path="themes/bootstrapdefault/js/rating.js"}
 {footer_script require='jquery'}
     var _pwgRatingAutoQueue = _pwgRatingAutoQueue||[];
     _pwgRatingAutoQueue.push( {ldelim}rootUrl: '{$ROOT_URL}', image_id: {$current.id},

--- a/template/search.tpl
+++ b/template/search.tpl
@@ -1,5 +1,5 @@
-{combine_css path="themes/`$themeconf.name`/selectize.js/dist/css/selectize.bootstrap2.css"}
-{combine_script id='jquery.selectize' load='footer' path="themes/`$themeconf.name`/selectize.js/dist/js/standalone/selectize.min.js"}
+{combine_css path="themes/bootstrapdefault/selectize.js/dist/css/selectize.bootstrap2.css"}
+{combine_script id='jquery.selectize' load='footer' path="themes/bootstrapdefault/selectize.js/dist/js/standalone/selectize.min.js"}
 {footer_script}
     jQuery(document).ready(function() {
     jQuery("#authors, #tags, #categories").each(function() {


### PR DESCRIPTION
Using  `$themeconf.name` in the `{combine_script}` and `{combine_css}` calls means that if you create a child theme of bootstrapdefault, the template system looks in the wrong place for those files.  For example, if I create a child theme called `mytheme`, it will look for `themes/mytheme/bootstrap/dist/css/bootstrap.min.css` instead of `themes/bootstrapdefault/bootstrap/dist/css/bootstrap.min.css`.

This means that you either have to create your own custom copies of these templates, or duplicate the JavaScript and CSS resources in your child theme.

Switching from `$themeconf.name` to `bootstrapdefault` solves this problem.