### PR TITLE
properly collapse navbars

### DIFF
--- a/template/index.tpl
+++ b/template/index.tpl
@@ -7,6 +7,12 @@
 <nav class="navbar navbar-default" role="navigation">
     <div class="container">
         <div class="navbar-header">
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#nav-primary">
+               <span class="sr-only">Toggle navigation</span>
+               <span class="icon-bar"></span>
+               <span class="icon-bar"></span>
+               <span class="icon-bar"></span>
+            </button>
             <div class="navbar-brand">
                 {$TITLE}
 {if isset($chronology.TITLE)}
@@ -14,7 +20,7 @@
 {/if}
             </div>
         </div>
-        <div class="navbar-right">
+        <div class="navbar-right navbar-collapse collapse" id="nav-primary">
             <ul class="nav navbar-nav">
 {if !empty($image_orders)}
                 <li class="dropdown">

--- a/template/picture.tpl
+++ b/template/picture.tpl
@@ -6,9 +6,15 @@
 <nav class="navbar navbar-default" role="navigation">
     <div class="container">
         <div class="navbar-header">
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#nav-secondary">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
             <div class="navbar-brand">{$SECTION_TITLE}{$LEVEL_SEPARATOR}<a href>{$current.TITLE}</a> [{$PHOTO}]</div>
         </div>
-        <div class="navbar-right">
+        <div class="navbar-right navbar-collapse collapse" id="nav-secondary">
             <ul class="nav navbar-nav">
 {if isset($current.unique_derivatives) && count($current.unique_derivatives)>1}
 {footer_script require='jquery'}{strip}


### PR DESCRIPTION
Currently the navbars do not collapse properly on small screens (mobile etc) as it's unclear for which of the navbars the button is for. The fix is to explicitly define the collapse button for each navbar with unique id and set class to "navbar-collapse collapse".