### PR TITLE
Fix batch manager plugin header menu display

### DIFF
--- a/template/menublock_batch_down.tpl
+++ b/template/menublock_batch_down.tpl
@@ -1,0 +1,8 @@
+<li class="dropdown">
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown">{$block->get_title()}<span class="caret"></span></a>
+    <ul class="dropdown-menu" role="menu">
+		{foreach from=$block->data item=link}
+			<li><a href="{$link.URL}" title="{$link.TITLE}"{if isset($link.REL)} {$link.REL}{/if}>{$link.NAME} [{$link.COUNT}]</a></li>
+		{/foreach}
+    </ul>
+</li>


### PR DESCRIPTION
Fixes the download header menu from the batch downloader plugin.  Instead of showing a table this will correct it with a dropdown display.